### PR TITLE
Fix LDAP Authenticator using user CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ This application uses the following environment vars:
 * `EXPIRE` - the time in seconds after which a token expires
 * `AUTH` - how to check user credentials, currently `noop` (all credentials are valid) and `ldap` are supported (defaults to `noop`)
 * `LDAP_HOSTS` - the host or hosts (comma separated) to use for ldap connect, **must** be specified if auth is `ldap`
-* `LDAP_USER_BASE_DN` - the ldap base [dn](https://www.ldap.com/ldap-dns-and-rdns) to locate users,**must** be specified if auth is `ldap`
+* `LDAP_USER_BASE_DN` - the ldap base [dn](https://www.ldap.com/ldap-dns-and-rdns) to locate users, **must** be specified if auth is `ldap`
+* `LDAP_BIND_DN` - the server connects to ldap using this user dn, **must** be specified if auth is `ldap`
+* `LDAP_BIND_PASSWORD` - the server connects to ldap using this password, **must** be specified if auth is `ldap`
+* `LDAP_SEARCH_TPL` - the filter string template used to find users (defaults to `(sAMAccountName=%s)`)
 * `CLIENT_STORE` - how to store the generated tokens. Currently `atom` and `riak` are supported (defaults to `atom`)
 * `RIAK_CLIENT_HOST` - **Must** be specified if client-store is `riak`
 * `RIAK_CLIENT_PORT` - the Riak HTTP port (defaults to `8098`)

--- a/src/lens/auth/ldap.clj
+++ b/src/lens/auth/ldap.clj
@@ -6,23 +6,30 @@
             [lens.descriptive :refer [Descriptive]]
             [clojure.string :as str]))
 
-(deftype Ldap [hosts base-dn conn]
+(def ^:private search-opts
+  {:attributes [:sAMAccountName :dn] :scope :one})
+
+(defrecord Ldap [hosts base-dn bind-dn bind-pw search-tpl conn]
   comp/Lifecycle
   (start [_]
-    (Ldap. hosts base-dn (ldap/connect {:host hosts})))
+    (let [conn (ldap/connect {:host hosts :bind-dn bind-dn :password bind-pw})]
+      (Ldap. hosts base-dn bind-dn bind-pw search-tpl conn)))
 
   (stop [_]
-    (Ldap. hosts base-dn nil))
+    (Ldap. hosts base-dn bind-dn bind-pw search-tpl nil))
 
   Authenticator
   (check-credentials [_ username password]
-    (let [bind-dn (str "CN=" username "," base-dn)]
-      (ldap/bind? conn bind-dn password)))
+    (let [opts (assoc search-opts :filter (format search-tpl username))
+          user (first (ldap/search conn base-dn opts))]
+      (and user (ldap/bind? conn (:dn user) password))))
 
   Descriptive
   (describe [_]
     (str "ldap on " hosts " and user-base: " base-dn)))
 
-(defnk create-ldap [ldap-hosts ldap-user-base-dn]
+(defnk create-ldap [ldap-hosts ldap-bind-dn ldap-bind-password ldap-user-base-dn
+                    {ldap-search-tpl "(sAMAccountName=%s)"}]
   (let [hosts (str/split (str/trim ldap-hosts) #"[\s,]")]
-    (->Ldap hosts ldap-user-base-dn nil)))
+    (->Ldap hosts ldap-user-base-dn ldap-bind-dn ldap-bind-password
+            ldap-search-tpl nil)))


### PR DESCRIPTION
The LDAP Authenticator used the user CN, which can be configured in
LDAP and is not equal to the sAMAccountName. In most cases the CN
looks something like 'lastname, firstname'. The search is now more
flexible and can be configured via env vars.
