### PR TITLE
Use LDAP account name instead of Request Param

### DIFF
--- a/src/lens/auth.clj
+++ b/src/lens/auth.clj
@@ -1,4 +1,13 @@
-(ns lens.auth)
+(ns lens.auth
+  (:require [schema.core :as s]))
+
+(s/def UserInfo
+  {:username s/Str})
 
 (defprotocol Authenticator
-  (check-credentials [this username password]))
+  (check-credentials* [this username password]))
+
+(s/defn check-credentials :- (s/maybe UserInfo) [auth username password]
+  "Checks whether the username and password combination is valid and returns
+  user information."
+  (check-credentials* auth username password))

--- a/src/lens/auth/ldap.clj
+++ b/src/lens/auth/ldap.clj
@@ -19,10 +19,11 @@
     (Ldap. hosts base-dn bind-dn bind-pw search-tpl nil))
 
   Authenticator
-  (check-credentials [_ username password]
+  (check-credentials* [_ username password]
     (let [opts (assoc search-opts :filter (format search-tpl username))
           user (first (ldap/search conn base-dn opts))]
-      (and user (ldap/bind? conn (:dn user) password))))
+      (when (and user (ldap/bind? conn (:dn user) password))
+        {:username (:sAMAccountName user)})))
 
   Descriptive
   (describe [_]

--- a/src/lens/auth/noop.clj
+++ b/src/lens/auth/noop.clj
@@ -12,8 +12,8 @@
     this)
 
   Authenticator
-  (check-credentials [_ _ _]
-    true)
+  (check-credentials* [_ username _]
+    {:username username})
 
   Descriptive
   (describe [_]

--- a/test/lens/test_util.clj
+++ b/test/lens/test_util.clj
@@ -24,5 +24,6 @@
 
 (deftype NoopWith [response]
   Authenticator
-  (check-credentials [_ _ _]
-    response))
+  (check-credentials* [_ username _]
+    (when response
+      {:username username})))


### PR DESCRIPTION
The username request param is not necessarily equal to the users
account name as LDAP authenticates 'TEST' as well as 'test'. To
identify a user on token introspection the server should respond with
the users account name.
